### PR TITLE
add requirements.txt, venv helper script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pandas

--- a/scripts/repo_activity.py
+++ b/scripts/repo_activity.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/scripts/repo_activity_REST.py
+++ b/scripts/repo_activity_REST.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/scripts/repo_activity_coc.py
+++ b/scripts/repo_activity_coc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# uncomment for more output
+# set -x
+python3 -m venv .venv
+echo "To activate virtual env: \"source .venv/bin/activate\""
+echo "To install dependencies: \"pip install -r requirements.txt"
+


### PR DESCRIPTION
### Description

- [x] add header to .py scripts so they can be run directly
- [x] change file mode (`chmod +x $filename`) accordingly 
- [x] add helper script to create a new python3 venv 
- [x] instructions to user on how to install dependencies (requests, pandas)
 
 
### Issues Resolved

none
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
